### PR TITLE
Three peerDependency more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-forcegraph",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Force-directed graph as a ThreeJS 3d object",
   "unpkg": "dist/three-forcegraph.min.js",
   "main": "dist/three-forcegraph.common.js",
@@ -45,7 +45,7 @@
     "tinycolor2": "^1.4.1"
   },
   "peerDependencies": {
-    "three": "^0.86.0"
+    "three": ">= 0.86 <= 1.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-forcegraph",
-  "version": "1.9.4",
+  "version": "1.9.3",
   "description": "Force-directed graph as a ThreeJS 3d object",
   "unpkg": "dist/three-forcegraph.min.js",
   "main": "dist/three-forcegraph.common.js",


### PR DESCRIPTION
This library can work with multiple three.js versions so there is no need to restrict versions unless breaking changes will be introduced.

I want to propose to make peerDependency more flexible so developer can decide which version should be used. Strict version conflicts with other three.js libs which have their own peerDependencies.