### PR TITLE
Add __graphObjType/Data to Group nested objects

### DIFF
--- a/src/forcegraph-kapsule.js
+++ b/src/forcegraph-kapsule.js
@@ -307,6 +307,13 @@ export default Kapsule({
       obj.__graphObjType = 'node'; // Add object type
       obj.__data = node; // Attach node data
 
+      if (Array.isArray(obj.children)) {
+        obj.children.forEach(child => {
+          child.__graphObjType = 'node';
+          child.__data = node;
+        });
+      }
+
       state.graphScene.add(node.__threeObj = obj);
     });
 


### PR DESCRIPTION
*Problem*:

`onNodeClick`, `onNodeHover` does not work for custom [Group](https://threejs.org/docs/#api/objects/Group) objects.

------

*Dependency*

https://github.com/vasturiano/3d-force-graph/pull/48

------

*Solution*

Adding `__graphObjType` and `__data` to every children object allows `raycaster.intersectObjects` from __3d-force-graph__ library work correct because intersectObjects returns object Mesh, not Group.

------

*Details*

I am using `nodeThreeObject` to return custom loaded 3D OBJ `xxxx.obj` with `xxxx.mtl`.
It's imported as a Group object with children Mesh objects. Similar results can be achieved by creating Group object and adding Mesh into it.

------

__IMPORTANT NOTE__: This solution does not solve nested nested objects problem ie if Group object contains Group object which contains Mesh object. It requires recursive calls for assigning `__graphObjType` or changing object architecture. Would be happy to discuss after initial PR as an improvement.