### PR TITLE
Dispose deallocated Material array

### DIFF
--- a/src/forcegraph-kapsule.js
+++ b/src/forcegraph-kapsule.js
@@ -413,7 +413,16 @@ export default Kapsule({
       // Clear the scene
       const deallocate = obj => {
         if (obj.geometry) { obj.geometry.dispose(); }
-        if (obj.material) { obj.material.dispose(); }
+        if (obj.material) {
+            if (Array.isArray(obj.material)) {
+                obj.material.forEach(material => {
+                    material.dispose();
+                });
+            }
+            else {
+                obj.material.dispose();
+            }
+          }
         if (obj.texture) { obj.texture.dispose(); }
         if (obj.children) { obj.children.forEach(deallocate) }
       };


### PR DESCRIPTION
Mesh composed of Material **Array()** cannot be disposed.
Throws error `Uncaught TypeError: e.material.dispose is not a function` while modifying graphData.

```
var box = new THREE.BoxGeometry(10, 10, 10);
var materials = [
	new THREE.MeshStandardMaterial({color: 'red'}),
	new THREE.MeshStandardMaterial({color: 'green'}),
	new THREE.MeshStandardMaterial({color: 'blue'}),
	new THREE.MeshStandardMaterial({color: 'cyan'}),
	new THREE.MeshStandardMaterial({color: 'magenta'}),
	new THREE.MeshStandardMaterial({color: 'yellow'}),
];
// 'materials' is of type Array()
return new THREE.Mesh(box, materials);
```

Array does not have dispose() function. Each children element should be disposed one by one.

https://gist.github.com/mys/ff6100af32790ed99890cf4378a14020