### PR TITLE
Add linkVisibility prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ myGraph.tickFrame();
 | <b>nodeThreeObject</b>([<i>Object3d</i>, <i>str</i> or <i>fn</i>]) | Node object accessor function or attribute for generating a custom 3d object to render as graph nodes. Should return an instance of [ThreeJS Object3d](https://threejs.org/docs/index.html#api/core/Object3D). If a <i>falsy</i> value is returned, the default 3d object type will be used instead for that node.  | *default node object is a sphere, sized according to `val` and styled according to `color`.* |
 | <b>linkSource</b>([<i>str</i>]) | Link object accessor attribute referring to id of source node. | `source` |
 | <b>linkTarget</b>([<i>str</i>]) | Link object accessor attribute referring to id of target node. | `target` |
+| <b>linkVisibility</b>([<i>boolean</i>, <i>str</i> or <i>fn</i>]) | Link object accessor function, attribute or a boolean constant for line visibility. A value of `false` keeps force without drawing link. | `true` |
 | <b>linkColor</b>([<i>str</i> or <i>fn</i>]) | Link object accessor function or attribute for line color. | `color` |
 | <b>linkAutoColorBy</b>([<i>str</i> or <i>fn</i>]) | Link object accessor function (`fn(link)`) or attribute (e.g. `'type'`) to automatically group colors by. Only affects links without a color attribute. | |
 | <b>linkOpacity</b>([<i>num</i>]) | Getter/setter for line opacity of all the links, between [0,1]. | 0.2 |

--- a/src/forcegraph-kapsule.js
+++ b/src/forcegraph-kapsule.js
@@ -114,6 +114,7 @@ export default Kapsule({
     nodeThreeObject: { onChange(_, state) { state.sceneNeedsRepopulating = true } },
     linkSource: { default: 'source', onChange(_, state) { state.simulationNeedsReheating = true } },
     linkTarget: { default: 'target', onChange(_, state) { state.simulationNeedsReheating = true } },
+    linkVisibility: { default: true, onChange(_, state) { state.sceneNeedsRepopulating = true } },
     linkColor: { default: 'color', onChange(_, state) { state.sceneNeedsRepopulating = true } },
     linkAutoColorBy: { onChange(_, state) { state.sceneNeedsRepopulating = true } },
     linkOpacity: { default: 0.2, onChange(_, state) { state.sceneNeedsRepopulating = true } },
@@ -469,6 +470,7 @@ export default Kapsule({
       });
 
       const customLinkMaterialAccessor = accessorFn(state.linkMaterial);
+      const linkVisibilityAccessor = accessorFn(state.linkVisibility);
       const linkColorAccessor = accessorFn(state.linkColor);
       const linkWidthAccessor = accessorFn(state.linkWidth);
       const linkArrowLengthAccessor = accessorFn(state.linkDirectionalArrowLength);
@@ -483,7 +485,7 @@ export default Kapsule({
       const particleGeometries = {}; // indexed by particle width
       state.graphData.links.forEach(link => {
 
-        if (link.visible !== undefined && link.visible == false) return;
+        if (!linkVisibilityAccessor(link)) return;
 
         // Add line
         const color = linkColorAccessor(link);

--- a/src/forcegraph-kapsule.js
+++ b/src/forcegraph-kapsule.js
@@ -482,6 +482,9 @@ export default Kapsule({
       const particleMaterials = {}; // indexed by link color
       const particleGeometries = {}; // indexed by particle width
       state.graphData.links.forEach(link => {
+
+        if (link.visible !== undefined && link.visible == false) return;
+
         // Add line
         const color = linkColorAccessor(link);
         const linkWidth = Math.ceil(linkWidthAccessor(link) * 10) / 10;


### PR DESCRIPTION
In my own simulation, some of links (minor) are invisible for performance purposes. This way the force still exists but the link is not being drawn.
Currently setting it via link.visible property. If false or 0 it is not rendered.
I am wondering if there is any more elegant solution to this.