### PR TITLE
Allow conditionally extending nodes/links

### DIFF
--- a/src/forcegraph-kapsule.js
+++ b/src/forcegraph-kapsule.js
@@ -507,8 +507,12 @@ export default Kapsule({
         }
 
         let obj;
-        if (customObj && !extendObj) {
-          obj = customObj;
+        if (!extendObj) {
+          if (customObj) {
+            obj = customObj;
+          } else {
+            return
+          }
         } else { // Add default object (sphere mesh)
           const val = valAccessor(node) || 1;
           if (!sphereGeometries.hasOwnProperty(val)) {
@@ -571,8 +575,12 @@ export default Kapsule({
         }
 
         let lineObj;
-        if (customObj && !extendObj) {
-          lineObj = customObj;
+        if (!extendObj) {
+          if (customObj) {
+            lineObj = customObj;
+          } else {
+            return
+          }
         } else {
           // Add default line object
           const linkWidth = Math.ceil(linkWidthAccessor(link) * 10) / 10;


### PR DESCRIPTION
When extending nodes (i.e. `nodeThreeObjectExtend` is `true`) it should be possible to conditionally return either a three object, or `undefined` from `nodeThreeObject`. The latter would be nice to have to be able to get the default node, and conditionally extend it.