### PR TITLE
Add nodeVisibility prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ myGraph.tickFrame();
 | <b>nodeColor</b>([<i>str</i> or <i>fn</i>]) | Node object accessor function or attribute for node color (affects sphere color). | `color` |
 | <b>nodeAutoColorBy</b>([<i>str</i> or <i>fn</i>]) | Node object accessor function (`fn(node)`) or attribute (e.g. `'type'`) to automatically group colors by. Only affects nodes without a color attribute. | |
 | <b>nodeOpacity</b>([<i>num</i>]) | Getter/setter for all the nodes sphere opacity, between [0,1]. | 0.75   |
+| <b>nodeVisibility</b>([<i>boolean</i>, <i>str</i> or <i>fn</i>]) | Node object accessor function, attribute or a boolean constant for whether to display the node. | `true` |
 | <b>nodeThreeObject</b>([<i>Object3d</i>, <i>str</i> or <i>fn</i>]) | Node object accessor function or attribute for generating a custom 3d object to render as graph nodes. Should return an instance of [ThreeJS Object3d](https://threejs.org/docs/index.html#api/core/Object3D). If a <i>falsy</i> value is returned, the default 3d object type will be used instead for that node.  | *default node object is a sphere, sized according to `val` and styled according to `color`.* |
 | <b>nodeThreeObjectExtend</b>([<i>bool</i>, <i>str</i> or <i>fn</i>]) | Node object accessor function, attribute or a boolean value for whether to replace the default node when using a custom `nodeThreeObject` (`false`) or to extend it (`true`).  | `false` |
 | <b>linkSource</b>([<i>str</i>]) | Link object accessor attribute referring to id of source node. | `source` |

--- a/src/forcegraph-kapsule.js
+++ b/src/forcegraph-kapsule.js
@@ -120,6 +120,7 @@ export default Kapsule({
     nodeColor: { default: 'color', onChange(_, state) { state.sceneNeedsRepopulating = true } },
     nodeAutoColorBy: { onChange(_, state) { state.sceneNeedsRepopulating = true } },
     nodeOpacity: { default: 0.75, onChange(_, state) { state.sceneNeedsRepopulating = true } },
+    nodeVisibility: { default: true, onChange(_, state) { state.sceneNeedsRepopulating = true } },
     nodeThreeObject: { onChange(_, state) { state.sceneNeedsRepopulating = true } },
     nodeThreeObjectExtend: { default: false, onChange(_, state) { state.sceneNeedsRepopulating = true } },
     linkSource: { default: 'source', onChange(_, state) { state.simulationNeedsReheating = true } },
@@ -495,9 +496,16 @@ export default Kapsule({
       const customNodeObjectExtendAccessor = accessorFn(state.nodeThreeObjectExtend);
       const valAccessor = accessorFn(state.nodeVal);
       const colorAccessor = accessorFn(state.nodeColor);
+      const visibilityAccessor = accessorFn(state.nodeVisibility);
       const sphereGeometries = {}; // indexed by node value
       const sphereMaterials = {}; // indexed by color
       state.graphData.nodes.forEach(node => {
+        if (!visibilityAccessor(node)) {
+          // Exclude non-visible nodes
+          node.__threeObj = null;
+          return;
+        }
+
         let customObj = customNodeObjectAccessor(node);
         const extendObj = customNodeObjectExtendAccessor(node);
 


### PR DESCRIPTION
This adds a `nodeVisibility` prop to mirror `linkVisibility`. If you think this is useful, would also need https://github.com/vasturiano/3d-force-graph/compare/master...stefanprobst:nodevisibility