### PR TITLE
feat: add condition for instanced mesh for positioning them correctly

### DIFF
--- a/src/forcegraph-kapsule.js
+++ b/src/forcegraph-kapsule.js
@@ -237,9 +237,24 @@ export default Kapsule({
 
           const pos = isD3Sim ? node : state.layout.getNodePosition(node[state.nodeId]);
 
-          obj.position.x = pos.x;
-          obj.position.y = pos.y || 0;
-          obj.position.z = pos.z || 0;
+          if (obj.isInstancedMesh) {
+            // get matrix
+            obj.getMatrixAt(node.index, obj.matrix);
+
+            // update position of the matrix
+            obj.matrix.setPosition(pos.x, pos.y || 0, pos.z || 0);
+
+            // update instance matrix
+            obj.setMatrixAt(node.index, obj.matrix);
+
+            obj.instanceMatrix.needsUpdate = true;
+          } else {
+            obj.position.x = pos.x;
+            obj.position.y = pos.y || 0;
+            obj.position.z = pos.z || 0;
+          }
+
+
         });
 
         // Update links position


### PR DESCRIPTION
Added a new condition that checks whether the object is an instanced mesh or not, so it can be assigned the correct position on the node.

Before, if you passed an instanced mesh all the nodes would have the same object reference of the instanced mesh and they would reassign the position of all the objects to the same location of the node in each iteration